### PR TITLE
BUG: add missing conditional for adding the end date

### DIFF
--- a/pycmc/artist.py
+++ b/pycmc/artist.py
@@ -130,8 +130,12 @@ def fanmetrics(
     """
     if end_date == "today":
         end_date = str(datetime.datetime.today()).split(" ")[0]
-    urlhandle = f"/artist/{cmid}/stat/{dsrc}"
-    params = dict(since=start_date,)  # until=end_date,)
+        params = dict(since=start_date,) 
+    else:
+        params = dict(until=end_date)
+
+    urlhandle = f"/artist/{cmid}/stat/{dsrc}" # until=end_date,)
+
     if valueCol is not None:
         params["field"] = valueCol
 


### PR DESCRIPTION
This fixes a regression bug that returns data up through the nearest date available, regardless of client `end_date` specification.

_`artist.fanmetrics` was missing a conditional `else` to set the `end_date` key/value within the `params` `dict`_:
![image](https://user-images.githubusercontent.com/16545607/89565928-e4d68200-d7e4-11ea-925a-0d5cdbb75640.png)
