### PR TITLE
Feature/fix start date regression

### DIFF
--- a/pycmc/artist.py
+++ b/pycmc/artist.py
@@ -130,11 +130,11 @@ def fanmetrics(
     """
     if end_date == "today":
         end_date = str(datetime.datetime.today()).split(" ")[0]
-        params = dict(since=start_date,) 
+        params = dict(since=start_date,)
     else:
-        params = dict(until=end_date)
+        params = dict(until=end_date, since=start_date,)
 
-    urlhandle = f"/artist/{cmid}/stat/{dsrc}" # until=end_date,)
+    urlhandle = f"/artist/{cmid}/stat/{dsrc}"  # until=end_date,)
 
     if valueCol is not None:
         params["field"] = valueCol

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,12 @@ def todayStr():
 
 @pytest.fixture(scope="module")
 def dates(todayStr):
-    return dict(start="2020-05-01", end=todayStr)
+    return dict(start="2020-05-01", end="2020-08-07") # fridays!
+
+
+@pytest.fixture(scope="module")
+def date(dates):
+    return dates["start"]
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def todayStr():
 
 @pytest.fixture(scope="module")
 def dates(todayStr):
-    return dict(start="2020-01-01", end=todayStr)
+    return dict(start="2020-05-01", end=todayStr)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -42,10 +42,10 @@ def test_fanmetrics(dates, caplog):
     test = pycmc.artist.fanmetrics("3380", dates["start"], dsrc="spotify")
     assert isinstance(test, type(dict()))
     assert len(test.keys())
-    assert test.get('listeners')
-    assert len(test['listeners'])
-    assert test['listeners'][0].get('timestp')
-    assert test['listeners'][0]['timestp'].split('T')[0] == dates['start']
+    assert test.get("listeners")
+    assert len(test["listeners"])
+    assert test["listeners"][0].get("timestp")
+    assert test["listeners"][0]["timestp"].split("T")[0] == dates["start"]
     #   broken upstream as of 2020-04-30
     #    test = pycmc.artist.fanmetrics('3380', dates['start'], dsrc='youtube')
     #    assert isinstance(test, type(dict()))
@@ -73,17 +73,16 @@ def test_fanmetrics(dates, caplog):
         )
         assert isinstance(test, type(dict()))
         assert len(test.keys())
- 
+
     for dsrc, valueCol in dsrcObj.items():
         time.sleep(2)
-        test = pycmc.artist.fanmetrics(
-            "1408480", '2020-07-15', dsrc, valueCol
-        )
+        test = pycmc.artist.fanmetrics("1408480", "2020-07-15", dsrc, valueCol)
         try:
             assert isinstance(test, type(dict()))
             assert len(test.keys())
         except AssertionError as aerr:
             logging.warning(f"Test assertion failed {aerr}: {dsrc} {valueCol}")
+
 
 def test_get_artist_ids():
     test = pycmc.artist.get_artist_ids("chartmetric", 4031)

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -42,6 +42,10 @@ def test_fanmetrics(dates, caplog):
     test = pycmc.artist.fanmetrics("3380", dates["start"], dsrc="spotify")
     assert isinstance(test, type(dict()))
     assert len(test.keys())
+    assert test.get('listeners')
+    assert len(test['listeners'])
+    assert test['listeners'][0].get('timestp')
+    assert test['listeners'][0]['timestp'].split('T')[0] == dates['start']
     #   broken upstream as of 2020-04-30
     #    test = pycmc.artist.fanmetrics('3380', dates['start'], dsrc='youtube')
     #    assert isinstance(test, type(dict()))
@@ -69,7 +73,7 @@ def test_fanmetrics(dates, caplog):
         )
         assert isinstance(test, type(dict()))
         assert len(test.keys())
-    
+ 
     for dsrc, valueCol in dsrcObj.items():
         time.sleep(2)
         test = pycmc.artist.fanmetrics(

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -28,7 +28,7 @@ def test_applemusic_tracks(dates):
 
 
 def test_applemusic_albums(dates):
-    test = pycmc.charts.applemusic.albums(dates["start"], "US")
+    test = pycmc.charts.applemusic.albums(dates["end"], "US")
     assert isinstance(test, list)
     assert len(test) > 90
     assert test[0]["name"] != ""
@@ -36,7 +36,7 @@ def test_applemusic_albums(dates):
 
 
 def test_applemusic_videos(dates):
-    test = pycmc.charts.applemusic.videos(dates["start"], "US")
+    test = pycmc.charts.applemusic.videos(dates["end"], "US")
     assert isinstance(test, list)
     assert len(test) > 90
     assert test[0]["name"] != ""
@@ -50,8 +50,9 @@ def test_beatport_tracks(dates):
     From the Chartmetric documentation,
     > This data is updated weekly only (on Fridays).
     """
-    test = pycmc.charts.beatport.tracks(dates["start"])
+    test = pycmc.charts.beatport.tracks(dates["end"])
     assert isinstance(test, list)
+    assert len(test)
     assert len(test) < 200
     assert test[0]["name"] != ""
     assert test[0]["id"] != ""
@@ -94,7 +95,7 @@ def test_deezer_insights(dates):
 
 
 def test_itunes_albums(dates):
-    test = pycmc.charts.itunes.albums(dates["start"])
+    test = pycmc.charts.itunes.albums(dates["end"])
     assert isinstance(test, list)
     assert len(test) > 100
     assert len(test) < 201
@@ -103,7 +104,7 @@ def test_itunes_albums(dates):
 
 
 def test_itunes_tracks(dates):
-    test = pycmc.charts.itunes.tracks(dates["start"])
+    test = pycmc.charts.itunes.tracks(dates["end"])
     assert isinstance(test, list)
     assert len(test) > 100
     assert len(test) < 201
@@ -112,7 +113,7 @@ def test_itunes_tracks(dates):
 
 
 def test_itunes_videos(dates):
-    test = pycmc.charts.itunes.videos(dates["start"])
+    test = pycmc.charts.itunes.videos(dates["end"])
     assert isinstance(test, list)
     assert len(test) > 100
     assert len(test) < 201
@@ -147,7 +148,7 @@ def test_soundcloud_tracks(dates):
     From the Chartmetric documentation,
     > This data is updated weekly only (on Fridays).
     """
-    test = pycmc.charts.soundcloud.tracks(dates["start"])
+    test = pycmc.charts.soundcloud.tracks(dates["end"])
     assert isinstance(test, list)
     assert len(test)
     assert len(test) > 90


### PR DESCRIPTION
This provides a patch for the incorrect `start_date` being returned for `fanmetric` calls with `end_date`= `'today'`, or when not provided.

In particular, we have added a test to specifically test for start dates:

![image](https://user-images.githubusercontent.com/16545607/89679402-9ee9ee80-d8b6-11ea-80b6-8ec452021049.png)

This is/will have to be passing for a merge + fix.