### PR TITLE
Add type parameter to search_engine.search

### DIFF
--- a/pycmc/search_engine.py
+++ b/pycmc/search_engine.py
@@ -1,9 +1,9 @@
 from . import utilities
 
 
-def search(query, limit=None, offset=None):
+def search(query, limit=None, offset=None, type="all"):
     """
-    Search the tracks, albums, artists, curators and playlists 
+    Search the tracks, albums, artists, curators and playlists
     with one single query.
 
     https://api.chartmetric.com/api/search
@@ -12,13 +12,19 @@ def search(query, limit=None, offset=None):
 
     - `query`:       string of search query, can be URLs
 
-    - `limit`:      int number of entries returned, default 10 
+    - `limit`:      int number of entries returned, default 10
 
     - `offset`:     int offset of entries returned, default 0
 
+    - `type`:       string defining search type, must be one of
+
+        'all' (default), 'artists', 'tracks', 'playlists',
+
+        'curators', 'albums', 'stations' or 'cities'.
+
     **Returns**
 
-    A dictionary of results, keys include 
+    A dictionary of results, keys include
 
         'artists', 'playlists', 'tracks',
         'curators', 'albums', 'labels',
@@ -26,7 +32,7 @@ def search(query, limit=None, offset=None):
 
     """
     urlhandle = f"/search"
-    params = {"q": query}
+    params = {"q": query, "type": type}
     if limit != None:
         params["limit"] = limit
     if offset != None:

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -16,3 +16,24 @@ def test_search(sr_keys):
         assert key in test.keys()
         result_len.append(len(test[key]) > 0)
     assert any(result_len)
+
+
+@pytest.mark.parametrize(
+    "type,query",
+    [
+        ("artists", "Dua Lipa"),
+        ("tracks", "Don't Start Now"),
+        ("playlists", "Today's Top Hits"),
+        ("curators", "Spotify"),
+        ("albums", "Future Nostalgia"),
+        ("stations", "Radio"),
+        ("cities", "Paris")
+    ]
+)
+def test_search_by_type(type, query):
+    test = pycmc.search_engine.search(query, type=type)
+    assert isinstance(test, dict)
+    assert set(test) == {type}
+    result_type = dict if type in ('playlists', 'curators') else list
+    assert isinstance(test[type], result_type)
+    assert len(test[type]) > 0


### PR DESCRIPTION
Hi, first off, thanks for this super useful library.

I've noticed that the `search_engine.search` function does not have a `type` parameter even though the `search` endpoint of the Chartmetric API does. This type parameter is quite useful as it makes the search much faster.

This pull request adds this feature and some corresponding tests. It's my first contribution to this project so please let me know if there's anything I've done wrong!